### PR TITLE
Make publicly exported types implement Debug trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_debug_implementations)]
+
 extern crate byteorder;
 extern crate num_traits;
 

--- a/src/proto/de.rs
+++ b/src/proto/de.rs
@@ -8,6 +8,7 @@ use serde::de::{
 
 use super::error::{ProtoError, ProtoResult};
 
+#[derive(Debug)]
 pub struct Deserializer<R: io::Read> {
     reader: R,
 }

--- a/src/proto/ser.rs
+++ b/src/proto/ser.rs
@@ -3,6 +3,7 @@ use serde::ser::{self, Serialize};
 use std::io;
 use super::error::{ProtoError, ProtoResult};
 
+#[derive(Debug)]
 pub struct Serializer<W: io::Write> {
     // This string starts empty and JSON is appended as values are serialized.
     writer: W


### PR DESCRIPTION
It seems to have become common practice for publicly exported types in a
library to implement the Debug trait. Doing so potentially simplifies
trouble shooting in client code directly but it also is a requirement in
case said client code embeds such objects and wants the wrappers to
implement this trait. For a deeper discussion of this topic please refer
to https://github.com/rust-lang/rust/pull/32054

To that end, this change adjust all publicly exported types to derive
from Debug. It also adds a crate wide lint enforcing this constraint.