### PR TITLE
Provide a more meaningful Display implementation for ProtoError

### DIFF
--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -1,4 +1,5 @@
 use std::{string, io};
+use std::error::Error;
 use std::fmt::Display;
 
 #[derive(Debug)]
@@ -67,7 +68,7 @@ impl std::error::Error for ProtoError {
 
 impl std::fmt::Display for ProtoError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "Error")
+        f.write_str(self.description())
     }
 }
 


### PR DESCRIPTION
ProtoError's Display just emits the string "Error". This behavior is not
very useful for real world clients.
With this change we forward the implementation to the Error::description
method in order to provide a bit more information as to what went wrong.