### PR TITLE
Make Ed25519*Key structs use Vec<u8> instead of String

### DIFF
--- a/src/proto/private_key.rs
+++ b/src/proto/private_key.rs
@@ -16,8 +16,8 @@ pub struct DssPrivateKey {
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Ed25519PrivateKey {
-    pub enc_a: String,
-    pub k_enc_a: String
+    pub enc_a: Vec<u8>,
+    pub k_enc_a: Vec<u8>
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]

--- a/src/proto/public_key.rs
+++ b/src/proto/public_key.rs
@@ -28,7 +28,7 @@ pub struct EcDsaPublicKey {
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Ed25519PublicKey {
-    pub enc_a: String
+    pub enc_a: Vec<u8>
 }
 
 #[derive(Clone, PartialEq, Debug)]


### PR DESCRIPTION
The Ed25519PublicKey and Ed25519PrivateKey structs store the key
material as a String. That unfortunately does not work as the actual
data may not be valid UTF-8.
With this change we adjust the types to use Vec<u8> instead of String
and, hence, avoiding any encoding related checks. This change resolves
issue #5.