### PR TITLE
Remove stale socket files before starting agent in key_storage example

### DIFF
--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -12,6 +12,7 @@ use ssh_agent::agent::Agent;
 
 use std::sync::RwLock;
 use std::error::Error;
+use std::fs::remove_file;
 
 use openssl::sign::Signer;
 use openssl::rsa::Rsa;
@@ -175,8 +176,10 @@ fn rsa_openssl_from_ssh(ssh_rsa: &RsaPrivateKey) -> Result<Rsa<Private>, Box<Err
 
 fn main() -> Result<(), Box<std::error::Error>> {
     let agent = KeyStorage::new();
+    let socket = "connect.sock";
+    let _ = remove_file(socket);
     
     env_logger::init();
-    agent.run_unix("connect.sock")?;
+    agent.run_unix(socket)?;
     Ok(())
 }


### PR DESCRIPTION
When the key_storage example is run twice, the second invocation fails
  > Error: Os { code: 98, kind: AddrInUse, message: "Address already in use" }

The problem is that the socket file is not cleaned up properly. With
this change we remove such a file before starting to listen for incoming
connections to prevent those errors.

----

I would hope that there is a better way to accomplish this feat, but I failed to
find it. If you have any idea feel free to discard this pull request.