### PR TITLE
Export SignatureBlob and Passphrase typedefs

### DIFF
--- a/src/proto/message.rs
+++ b/src/proto/message.rs
@@ -54,8 +54,8 @@ pub struct Extension {
     extension_contents: Vec<u8>
 }
 
-type Passphrase = String;
-type SignatureBlob = Vec<u8>;
+pub type Passphrase = String;
+pub type SignatureBlob = Vec<u8>;
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub enum Message {


### PR DESCRIPTION
The SignatureBlob and Passphrase types, despite contained in the
exported Message enum, are private to the crate. While that is not
strictly wrong, it can make for some non-obvious client code that just
passes around Vec<u8> and String objects.
With this change we make those two typedefs available to user code.