### PR TITLE
Accept AsRef<Path> in Agent::run_unix signature

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -3,10 +3,11 @@ use tokio::net::TcpListener;
 use std::net::SocketAddr;
 use tokio::prelude::*;
 
-use std::mem::size_of;
 use std::error::Error;
-use std::sync::Arc;
 use std::fmt::Debug;
+use std::mem::size_of;
+use std::path::Path;
+use std::sync::Arc;
 
 use super::proto::{from_bytes, to_bytes};
 use super::proto::message::Message;
@@ -89,7 +90,7 @@ pub trait Agent: 'static + Sync + Send + Sized {
         Box::new(FutureResult::from(self.handle(message)))
     }
     
-    fn run_unix(self, path: &str) -> Result<(), Box<Error>> {
+    fn run_unix(self, path: impl AsRef<Path>) -> Result<(), Box<Error>> {
         let socket = UnixListener::bind(path)?;
         Ok(tokio::run(handle_clients!(self, socket)))
     }


### PR DESCRIPTION
The run_unix method on the Agent trait currently expects an str
describing the path of the domain socket to use. That appears to be an
unnecessary restriction. For one, tokio's UnixListener::bind (the only
user of this path) is more flexible, accepting anything satisfying
AsRef<Path>. But perhaps more importantly it forces clients to convert
into a string first, which in turns checks for valid UTF-8 which,
depending on the system, may not actually be an invariant enforced for
paths by the file system.
With this change we adjust the method's signature to accept a any
AsRef<Path>.