### PR TITLE
Reference GitHub repository from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Nicolas Trippar <ntrippar@gmail.com>",
     "Federico Pomar <fmpomar@users.noreply.github.com>"
 ]
+repository = "https://github.com/sekey/ssh-agent.rs.git"
 readme = "README.md"
 edition = "2018"
 


### PR DESCRIPTION
The crates.io released version does not contain a link to the GitHub
repository used for development of the crate. That makes it unnecessary
hard for people to figure out how to contribute or access the version
controlled history.
With this change we reference the GitHub repository from Cargo.toml
which will translate to a link on crates.io after the next release.