### PR TITLE
Implement Eq and Hash for private and public key types

### DIFF
--- a/src/proto/private_key.rs
+++ b/src/proto/private_key.rs
@@ -5,7 +5,7 @@ use super::key_type::{KeyType, KeyTypeEnum};
 
 pub type MpInt = Vec<u8>;
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DssPrivateKey {
     pub p: MpInt,
     pub q: MpInt,
@@ -14,13 +14,13 @@ pub struct DssPrivateKey {
     pub x: MpInt
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Ed25519PrivateKey {
     pub enc_a: Vec<u8>,
     pub k_enc_a: Vec<u8>
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct RsaPrivateKey {
     pub n: MpInt,
     pub e: MpInt,
@@ -30,14 +30,14 @@ pub struct RsaPrivateKey {
     pub q: MpInt
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EcDsaPrivateKey {
     pub identifier: String,
     pub q: MpInt,
     pub d: MpInt
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PrivateKey {
     Dss(DssPrivateKey),
     Ed25519(Ed25519PrivateKey),

--- a/src/proto/public_key.rs
+++ b/src/proto/public_key.rs
@@ -6,13 +6,13 @@ use super::key_type::{KeyType, KeyTypeEnum};
 
 pub type MpInt = Vec<u8>;
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct RsaPublicKey {
     pub e: MpInt,
     pub n: MpInt
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DssPublicKey {
     pub p: MpInt,
     pub q: MpInt,
@@ -20,18 +20,18 @@ pub struct DssPublicKey {
     pub y: MpInt
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EcDsaPublicKey {
     pub identifier: String,
     pub q: MpInt
 }
 
-#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Ed25519PublicKey {
     pub enc_a: Vec<u8>
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PublicKey {
     Dss(DssPublicKey),
     Ed25519(Ed25519PublicKey),


### PR DESCRIPTION
This change implements the Eq and Hash traits for the public and private
key types. Both traits are trivially available for those simple types,
as they are composed only of objects that implement those traits as well.
The implementation of those traits is a necessity when using them in a
HashMap, for example.