### PR TITLE
Remove unused num-derive dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ codecov = { repository = "sekey/ssh-agent.rs" }
 
 [dependencies]
 byteorder = "1.2.7"
-num-derive = "0.2"
 num-traits = "0.2"
 serde = "1.0.87"
 serde_derive = "1.0.87"


### PR DESCRIPTION
The dependency on num-derive is not actually required. This change
removes it.