### PR TITLE
[RFC] Zero out private keys on Drop

### DIFF
--- a/src/proto/private_key.rs
+++ b/src/proto/private_key.rs
@@ -1,10 +1,24 @@
 use serde::{Deserialize, Serialize};
 use serde::de::{Deserializer, Error};
 use serde::ser::{Serializer, SerializeTuple};
+
+use std::mem::zeroed;
+use std::ptr::write_volatile;
+
 use super::error::ProtoError;
 use super::key_type::{KeyType, KeyTypeEnum};
 
 pub type MpInt = Vec<u8>;
+
+macro_rules! ClearOnDrop {
+    ($name:ident) => {
+        impl Drop for $name {
+            fn drop(&mut self) {
+                unsafe{ write_volatile(self, zeroed()) };
+            }
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DssPrivateKey {
@@ -14,12 +28,14 @@ pub struct DssPrivateKey {
     pub y: MpInt,
     pub x: MpInt
 }
+ClearOnDrop!(DssPrivateKey);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Ed25519PrivateKey {
     pub enc_a: Vec<u8>,
     pub k_enc_a: Vec<u8>
 }
+ClearOnDrop!(Ed25519PrivateKey);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct RsaPrivateKey {
@@ -30,6 +46,7 @@ pub struct RsaPrivateKey {
     pub p: MpInt,
     pub q: MpInt
 }
+ClearOnDrop!(RsaPrivateKey);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct EcDsaPrivateKey {
@@ -37,6 +54,7 @@ pub struct EcDsaPrivateKey {
     pub q: MpInt,
     pub d: MpInt
 }
+ClearOnDrop!(EcDsaPrivateKey);
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PrivateKey {

--- a/src/proto/public_key.rs
+++ b/src/proto/public_key.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use serde::de::{Deserializer, Error};
 use serde::ser::{Serializer, SerializeTuple};
+
+use std::mem::{replace, zeroed};
+
 use super::error::ProtoError;
 use super::private_key::*;
 use super::key_type::{KeyType, KeyTypeEnum};
@@ -72,38 +75,38 @@ impl From<PrivateKey> for PublicKey {
 }
 
 impl From<RsaPrivateKey> for RsaPublicKey {
-    fn from(key: RsaPrivateKey) -> Self {
+    fn from(mut key: RsaPrivateKey) -> Self {
         Self {
-            e: key.e,
-            n: key.n
+            e: replace(&mut key.e, unsafe { zeroed() }),
+            n: replace(&mut key.n, unsafe { zeroed() })
         }
     }
 }
 
 impl From<DssPrivateKey> for DssPublicKey {
-    fn from(key: DssPrivateKey) -> Self {
+    fn from(mut key: DssPrivateKey) -> Self {
         Self {
-            p: key.p,
-            q: key.q,
-            g: key.g,
-            y: key.y
+            p: replace(&mut key.p, unsafe { zeroed() }),
+            q: replace(&mut key.q, unsafe { zeroed() }),
+            g: replace(&mut key.g, unsafe { zeroed() }),
+            y: replace(&mut key.y, unsafe { zeroed() })
         }
     }
 }
 
 impl From<EcDsaPrivateKey> for EcDsaPublicKey {
-    fn from(key: EcDsaPrivateKey) -> Self {
+    fn from(mut key: EcDsaPrivateKey) -> Self {
         Self {
-            identifier: key.identifier,
-            q: key.q
+            identifier: replace(&mut key.identifier, unsafe { zeroed() }),
+            q: replace(&mut key.q, unsafe { zeroed() })
         }
     }
 }
 
 impl From<Ed25519PrivateKey> for Ed25519PublicKey {
-    fn from(key: Ed25519PrivateKey) -> Self {
+    fn from(mut key: Ed25519PrivateKey) -> Self {
         Self {
-            enc_a: key.enc_a
+            enc_a: replace(&mut key.enc_a, unsafe { zeroed() })
         }
     }
 }
@@ -145,5 +148,3 @@ impl_key_type_enum_ser_de!(
     (PublicKey::EcDsa, EcDsaPublicKey),
     (PublicKey::Ed25519, Ed25519PublicKey)
 );
-
-


### PR DESCRIPTION
Should we zero out sensitive key material? [Various](https://crypto.stackexchange.com/questions/9998/should-i-delete-cryptographic-data-from-memory) (meta) [sources](https://stackoverflow.com/questions/1263350/cryptography-best-practices-for-keys-in-memory) seem to indicate that this is still a thing.

I drafted something up, but I am not sure if it's a great solution: private keys have public fields and implementing drop for the key itself prevents a simple move of attributes out of it, which makes handling awkward.

Do you have an opinion on the matter?