### PR TITLE
Prefix trait objects with 'dyn'

### DIFF
--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -62,7 +62,7 @@ impl KeyStorage {
         }
     }
     
-    fn identity_remove(&self, pubkey: &PublicKey) -> Result<(), Box<Error>> {
+    fn identity_remove(&self, pubkey: &PublicKey) -> Result<(), Box<dyn Error>> {
         let mut identities = self.identities.write().unwrap();
         
         if let Some(index) = Self::identity_index_from_pubkey(&identities, &pubkey) {
@@ -73,7 +73,7 @@ impl KeyStorage {
         }
     }
     
-    fn sign(&self, sign_request: &SignRequest) -> Result<Signature, Box<Error>> {
+    fn sign(&self, sign_request: &SignRequest) -> Result<Signature, Box<dyn Error>> {
         let pubkey: PublicKey = from_bytes(&sign_request.pubkey_blob)?;
         
         if let Some(identity) = self.identity_from_pubkey(&pubkey) {
@@ -109,7 +109,7 @@ impl KeyStorage {
         }
     }
     
-    fn handle_message(&self, request: Message) -> Result<Message, Box<Error>>  {
+    fn handle_message(&self, request: Message) -> Result<Message, Box<dyn Error>>  {
         info!("Request: {:?}", request);
         let response = match request {
             Message::RequestIdentities => {
@@ -158,7 +158,7 @@ impl Agent for KeyStorage {
 }
 
 
-fn rsa_openssl_from_ssh(ssh_rsa: &RsaPrivateKey) -> Result<Rsa<Private>, Box<Error>> {
+fn rsa_openssl_from_ssh(ssh_rsa: &RsaPrivateKey) -> Result<Rsa<Private>, Box<dyn Error>> {
     let n = BigNum::from_slice(&ssh_rsa.n)?;
     let e = BigNum::from_slice(&ssh_rsa.e)?;
     let d = BigNum::from_slice(&ssh_rsa.d)?;
@@ -171,7 +171,7 @@ fn rsa_openssl_from_ssh(ssh_rsa: &RsaPrivateKey) -> Result<Rsa<Private>, Box<Err
     Ok(Rsa::from_private_components(n, e, d, p, q, dp, dq, qi)?)
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let agent = KeyStorage::new();
     let socket = "connect.sock";
     let _ = remove_file(socket);

--- a/examples/key_storage.rs
+++ b/examples/key_storage.rs
@@ -171,7 +171,7 @@ fn rsa_openssl_from_ssh(ssh_rsa: &RsaPrivateKey) -> Result<Rsa<Private>, Box<dyn
     Ok(Rsa::from_private_components(n, e, d, p, q, dp, dq, qi)?)
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let agent = KeyStorage::new();
     let socket = "connect.sock";
     let _ = remove_file(socket);

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -87,12 +87,12 @@ pub trait Agent: 'static + Sync + Send + Sized {
         Box::new(FutureResult::from(self.handle(message)))
     }
     
-    fn run_unix(self, path: impl AsRef<Path>) -> Result<(), Box<dyn Error>> {
+    fn run_unix(self, path: impl AsRef<Path>) -> Result<(), Box<dyn Error + Send + Sync>> {
         let socket = UnixListener::bind(path)?;
         Ok(tokio::run(handle_clients!(self, socket)))
     }
 
-    fn run_tcp(self, addr: &str) -> Result<(), Box<dyn Error>> {
+    fn run_tcp(self, addr: &str) -> Result<(), Box<dyn Error + Send + Sync>> {
         let socket = TcpListener::bind(&addr.parse::<SocketAddr>()?)?;
         Ok(tokio::run(handle_clients!(self, socket)))
     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -83,16 +83,16 @@ pub trait Agent: 'static + Sync + Send + Sized {
     fn handle_async(
         &self,
         message: Message
-    ) -> Box<Future<Item = Message, Error = Self::Error> + Send + Sync> {
+    ) -> Box<dyn Future<Item = Message, Error = Self::Error> + Send + Sync> {
         Box::new(FutureResult::from(self.handle(message)))
     }
     
-    fn run_unix(self, path: impl AsRef<Path>) -> Result<(), Box<Error>> {
+    fn run_unix(self, path: impl AsRef<Path>) -> Result<(), Box<dyn Error>> {
         let socket = UnixListener::bind(path)?;
         Ok(tokio::run(handle_clients!(self, socket)))
     }
 
-    fn run_tcp(self, addr: &str) -> Result<(), Box<Error>> {
+    fn run_tcp(self, addr: &str) -> Result<(), Box<dyn Error>> {
         let socket = TcpListener::bind(&addr.parse::<SocketAddr>()?)?;
         Ok(tokio::run(handle_clients!(self, socket)))
     }

--- a/src/proto/error.rs
+++ b/src/proto/error.rs
@@ -54,7 +54,7 @@ impl std::error::Error for ProtoError {
         }
     }
 
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match self {
             ProtoError::UnexpectedVariant => None,
             ProtoError::MessageTooLong => None,


### PR DESCRIPTION
Compilation of the crate results in a bunch of warnings along the lines
of:
> warning: trait objects without an explicit `dyn` are deprecated

This change fixes all the occurrences.