### PR TITLE
Make `impl_key_type_enum_ser_de!` private

### DIFF
--- a/src/proto/key_type.rs
+++ b/src/proto/key_type.rs
@@ -9,7 +9,6 @@ pub trait KeyType {
     }
 }
 
-#[macro_export]
 macro_rules! impl_key_type_enum_ser_de {
     ($class_name:path, $(($variant_name:path, $variant_class:ty)),* ) => {
         impl KeyTypeEnum for $class_name {


### PR DESCRIPTION
It doesn't look like this macro is intended to be consumed by users, so make it private