### PR TITLE
agent: Add `run_listener` to the Agent trait

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -87,9 +87,12 @@ pub trait Agent: 'static + Sync + Send + Sized {
         Box::new(FutureResult::from(self.handle(message)))
     }
     
-    fn run_unix(self, path: impl AsRef<Path>) -> Result<(), Box<dyn Error + Send + Sync>> {
-        let socket = UnixListener::bind(path)?;
+    fn run_listener(self, socket: UnixListener) -> Result<(), Box<dyn Error + Send + Sync>> {
         Ok(tokio::run(handle_clients!(self, socket)))
+    }
+
+    fn run_unix(self, path: impl AsRef<Path>) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.run_listener(UnixListener::bind(path)?)
     }
 
     fn run_tcp(self, addr: &str) -> Result<(), Box<dyn Error + Send + Sync>> {


### PR DESCRIPTION
This change exposes `Agent::run_listener` that takes a raw `UnixListener` object.

This allows starting the agent with listeners that are backed by raw file descriptors. This in turn makes writing agents that are started with [systemd's socket activation][0].

[0]: https://0pointer.de/blog/projects/socket-activation.html

The following example starts the agent from systemd's supplied input:

```rs
use std::os::unix::io::FromRawFd;

let fds = std::env::var("LISTEN_FDS").unwrap();
let fds: i32 = fds.parse()?;
let listener = unsafe { std::os::unix::net::UnixListener::from_raw_fd(fds + 2) };
listener.set_nonblocking(true)?;

let handle = tokio_reactor::Handle::default();
let listener = tokio_uds::UnixListener::from_std(listener, &handle)?;

let agent = Backend::default();
agent.run_listener(listener);
```