### PR TITLE
define key structures of sk-ecdsa and sk-ed25519

### DIFF
--- a/src/proto/private_key.rs
+++ b/src/proto/private_key.rs
@@ -22,6 +22,15 @@ pub struct Ed25519PrivateKey {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SkEd25519PrivateKey {
+    pub enc_a: Vec<u8>,
+    pub application: String,
+    pub flags: u8,
+    pub key_handle: Vec<u8>,
+    pub reserved: Vec<u8>
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct RsaPrivateKey {
     pub n: MpInt,
     pub e: MpInt,
@@ -38,12 +47,24 @@ pub struct EcDsaPrivateKey {
     pub d: MpInt
 }
 
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SkEcDsaPrivateKey {
+    pub identifier: String,
+    pub q: MpInt,
+    pub application: String,
+    pub flags: u8,
+    pub key_handle: Vec<u8>,
+    pub reserved: Vec<u8>
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PrivateKey {
     Dss(DssPrivateKey),
     Ed25519(Ed25519PrivateKey),
+    SkEd25519(SkEd25519PrivateKey),
     Rsa(RsaPrivateKey),
-    EcDsa(EcDsaPrivateKey)
+    EcDsa(EcDsaPrivateKey),
+    SkEcDsa(SkEcDsaPrivateKey)
 }
 
 impl KeyType for RsaPrivateKey {
@@ -58,6 +79,10 @@ impl KeyType for Ed25519PrivateKey {
     const KEY_TYPE: &'static str = "ssh-ed25519";
 }
 
+impl KeyType for SkEd25519PrivateKey {
+    const KEY_TYPE: &'static str = "sk-ssh-ed25519@openssh.com";
+}
+
 impl KeyType for EcDsaPrivateKey {
     const KEY_TYPE: &'static str = "ecdsa-sha2";
     
@@ -66,10 +91,20 @@ impl KeyType for EcDsaPrivateKey {
     }
 }
 
+impl KeyType for SkEcDsaPrivateKey {
+    const KEY_TYPE: &'static str = "sk-ecdsa-sha2";
+
+    fn key_type(&self) -> String {
+        format!("{}-{}@openssh.com", Self::KEY_TYPE, self.identifier)
+    }
+}
+
 impl_key_type_enum_ser_de!(
     PrivateKey,
     (PrivateKey::Dss, DssPrivateKey),
     (PrivateKey::Rsa, RsaPrivateKey),
     (PrivateKey::EcDsa, EcDsaPrivateKey),
-    (PrivateKey::Ed25519, Ed25519PrivateKey)
+    (PrivateKey::SkEcDsa, SkEcDsaPrivateKey),
+    (PrivateKey::Ed25519, Ed25519PrivateKey),
+    (PrivateKey::SkEd25519, SkEd25519PrivateKey)
 );

--- a/src/proto/public_key.rs
+++ b/src/proto/public_key.rs
@@ -28,16 +28,32 @@ pub struct EcDsaPublicKey {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SkEcDsaPublicKey {
+    pub identifier: String,
+    pub q: MpInt,
+    pub application: String,
+}
+
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Ed25519PublicKey {
     pub enc_a: Vec<u8>
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub struct SkEd25519PublicKey {
+    pub enc_a: Vec<u8>,
+    pub application: String,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum PublicKey {
     Dss(DssPublicKey),
     Ed25519(Ed25519PublicKey),
+    SkEd25519(SkEd25519PublicKey),
     Rsa(RsaPublicKey),
-    EcDsa(EcDsaPublicKey)
+    EcDsa(EcDsaPublicKey),
+    SkEcDsa(SkEcDsaPublicKey),
 }
 
 impl KeyType for RsaPublicKey {
@@ -57,6 +73,18 @@ impl KeyType for EcDsaPublicKey {
     
     fn key_type(&self) -> String {
         format!("{}-{}", Self::KEY_TYPE, self.identifier)
+    }
+}
+
+impl KeyType for SkEd25519PublicKey {
+    const KEY_TYPE: &'static str = "sk-ssh-ed25519@openssh.com";
+}
+
+impl KeyType for SkEcDsaPublicKey {
+    const KEY_TYPE: &'static str = "sk-ecdsa-sha2";
+    
+    fn key_type(&self) -> String {
+        format!("{}-{}@openssh.com", Self::KEY_TYPE, self.identifier)
     }
 }
 
@@ -143,7 +171,9 @@ impl_key_type_enum_ser_de!(
     (PublicKey::Dss, DssPublicKey),
     (PublicKey::Rsa, RsaPublicKey),
     (PublicKey::EcDsa, EcDsaPublicKey),
-    (PublicKey::Ed25519, Ed25519PublicKey)
+    (PublicKey::SkEcDsa, SkEcDsaPublicKey),
+    (PublicKey::Ed25519, Ed25519PublicKey),
+    (PublicKey::SkEd25519, SkEd25519PublicKey)
 );
 
 

--- a/src/proto/public_key.rs
+++ b/src/proto/public_key.rs
@@ -34,7 +34,6 @@ pub struct SkEcDsaPublicKey {
     pub application: String,
 }
 
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Ed25519PublicKey {
     pub enc_a: Vec<u8>
@@ -82,7 +81,7 @@ impl KeyType for SkEd25519PublicKey {
 
 impl KeyType for SkEcDsaPublicKey {
     const KEY_TYPE: &'static str = "sk-ecdsa-sha2";
-    
+
     fn key_type(&self) -> String {
         format!("{}-{}@openssh.com", Self::KEY_TYPE, self.identifier)
     }
@@ -93,8 +92,10 @@ impl From<PrivateKey> for PublicKey {
         match key {
             PrivateKey::Dss(key) => PublicKey::Dss(DssPublicKey::from(key)),
             PrivateKey::Ed25519(key) => PublicKey::Ed25519(Ed25519PublicKey::from(key)),
+            PrivateKey::SkEd25519(key) => PublicKey::SkEd25519(SkEd25519PublicKey::from(key)),
             PrivateKey::Rsa(key) => PublicKey::Rsa(RsaPublicKey::from(key)),
             PrivateKey::EcDsa(key) => PublicKey::EcDsa(EcDsaPublicKey::from(key)),
+            PrivateKey::SkEcDsa(key) => PublicKey::SkEcDsa(SkEcDsaPublicKey::from(key)),
         }
     }
 }
@@ -128,10 +129,29 @@ impl From<EcDsaPrivateKey> for EcDsaPublicKey {
     }
 }
 
+impl From<SkEcDsaPrivateKey> for SkEcDsaPublicKey {
+    fn from(key: SkEcDsaPrivateKey) -> Self {
+        Self {
+            identifier: key.identifier,
+            q: key.q,
+            application: key.application
+        }
+    }
+}
+
 impl From<Ed25519PrivateKey> for Ed25519PublicKey {
     fn from(key: Ed25519PrivateKey) -> Self {
         Self {
             enc_a: key.enc_a
+        }
+    }
+}
+
+impl From<SkEd25519PrivateKey> for SkEd25519PublicKey {
+    fn from(key: SkEd25519PrivateKey) -> Self {
+        Self {
+            enc_a: key.enc_a,
+            application: key.application
         }
     }
 }

--- a/src/proto/signature.rs
+++ b/src/proto/signature.rs
@@ -16,6 +16,14 @@ pub struct Signature {
 }
 
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
+pub struct SkSignature {
+    pub algorithm: String,
+    pub blob: Vec<u8>,
+    pub flags: u8,
+    pub counter: u32
+}
+
+#[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct EcDsaSignature {
     pub identifier: String,
     pub data: EcDsaSignatureData


### PR DESCRIPTION
OpenSSH supports hardware-backed authentication keys since v8.2

Currently, only two types are defined (namely `sk-ssh-ed25519@openssh.com` and `sk-ecdsa-sha2-nistp256@openssh.com`) according to https://github.com/openssh/openssh-portable/blob/master/PROTOCOL.u2f

This patch defines corresponding structures for these two types of keys.